### PR TITLE
Build news and research page

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -11,6 +11,7 @@ import Login from '../pages/Login'
 import Register from '../pages/Register'
 import Profile from '../pages/Profile'
 import Layout from '../components/layout/Layout'
+import NewsPage from '../pages/news/NewsPage'
 
 // Loading component
 function Loading() {
@@ -60,6 +61,7 @@ export default function AppRoutes() {
             <Route path="/me" element={user ? <MyStocks /> : <Navigate to="/login" replace />} />
             <Route path="/mystocks" element={user ? <MyStocks /> : <Navigate to="/login" replace />} />
             <Route path="/settings" element={user ? <Settings /> : <Navigate to="/login" replace />} />
+            <Route path="/news" element={user ? <NewsPage /> : <Navigate to="/login" replace />} />
             <Route path="/u/:handle" element={<PublicProfile />} />
             <Route path="/profile/:name" element={<Profile />} />
             <Route path="/position/:id" element={<PositionDetail />} />

--- a/src/components/nav/BottomTabBar.tsx
+++ b/src/components/nav/BottomTabBar.tsx
@@ -3,6 +3,7 @@ import { useAuthStore } from '../../stores/authStore'
 import { t } from '../../lib/i18n'
 
 const items = [
+  { to: '/news', labelKey: 'news' as const },
   { to: '/', labelKey: 'hub' as const },
   { to: '/social', labelKey: 'social' as const },
   { to: '/me', labelKey: 'myStocks' as const },
@@ -20,7 +21,7 @@ export default function BottomTabBar() {
   
   return (
     <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-zinc-800 bg-zinc-950/80 backdrop-blur">
-      <div className="mx-auto grid max-w-md grid-cols-4 text-center text-xs">
+      <div className="mx-auto grid max-w-md grid-cols-5 text-center text-xs">
         {items.map((it) => {
           const active = pathname === it.to || (it.to === '/me' && pathname === '/mystocks')
           return (

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -9,6 +9,7 @@ const en = {
   totalValue: 'Total Value',
   totalPnL: 'Total P/L',
   today: 'Today',
+  news: 'News',
 };
 
 const he: typeof en = {

--- a/src/pages/news/NewsPage.tsx
+++ b/src/pages/news/NewsPage.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react'
+import { useNews } from '@/state/newsSlice'
+import TodayBrief from './components/TodayBrief'
+import MarketSnapshot from './components/MarketSnapshot'
+import ResearchRankings from './components/ResearchRankings'
+import HeadlinesForYou from './components/HeadlinesForYou'
+
+export default function NewsPage() {
+  const { loadBrief, loadSnapshot, loadRankings, loadHeadlines } = useNews()
+
+  useEffect(() => {
+    // fire and forget parallel
+    loadBrief()
+    loadSnapshot()
+    loadRankings()
+    loadHeadlines()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <div className="pb-24">
+      <header className="sticky top-0 z-10 bg-zinc-950/80 backdrop-blur px-1 py-3">
+        <h1 className="text-xl font-semibold">News & Research</h1>
+        <p className="text-xs text-zinc-400">Auto-refreshed. Works offline with cached data.</p>
+      </header>
+
+      <TodayBrief />
+      <MarketSnapshot />
+      <ResearchRankings />
+      <HeadlinesForYou />
+    </div>
+  )
+}

--- a/src/pages/news/components/HeadlinesForYou.tsx
+++ b/src/pages/news/components/HeadlinesForYou.tsx
@@ -1,0 +1,38 @@
+import { useNews } from '@/state/newsSlice'
+
+export default function HeadlinesForYou() {
+  const { headlines, status } = useNews()
+
+  if (status === 'loading' && !headlines.length) {
+    return <div className="skeleton h-24 rounded-lg my-2" />
+  }
+
+  if (!headlines.length) return null
+
+  return (
+    <section className="mt-6">
+      <h2 className="text-sm font-medium mb-2">Headlines for You</h2>
+      <ul className="space-y-3">
+        {headlines.map((h) => (
+          <li key={h.id} className="rounded-lg border border-zinc-800 p-3">
+            <div className="flex justify-between text-xs text-zinc-500 mb-1">
+              <span>{h.source}</span>
+              <span>{new Date(h.published_at).toLocaleTimeString()}</span>
+            </div>
+            <a href={h.url} target="_blank" rel="noopener noreferrer" className="font-medium hover:underline">
+              {h.title}
+            </a>
+            {h.summary ? <p className="mt-1 text-sm text-zinc-400 line-clamp-2">{h.summary}</p> : null}
+            <div className="mt-2 flex flex-wrap gap-1 text-xs">
+              {h.tickers.map((t) => (
+                <span key={t} className="rounded-full bg-zinc-800 px-2 py-0.5">
+                  {t}
+                </span>
+              ))}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/pages/news/components/MarketSnapshot.tsx
+++ b/src/pages/news/components/MarketSnapshot.tsx
@@ -1,0 +1,28 @@
+import { useNews } from '@/state/newsSlice'
+
+export default function MarketSnapshot() {
+  const { snapshot, status } = useNews()
+
+  if (status === 'loading' && !snapshot.length) {
+    return <div className="skeleton h-16 rounded-lg my-2" />
+  }
+
+  if (!snapshot.length) return null
+
+  return (
+    <section className="mt-4">
+      <h2 className="text-sm font-medium mb-2">Market Snapshot</h2>
+      <div className="grid grid-cols-3 gap-2">
+        {snapshot.map((s) => (
+          <div key={s.symbol} className="rounded-lg border border-zinc-800 p-2">
+            <div className="text-xs text-zinc-400">{s.symbol}</div>
+            <div className="text-lg font-semibold">{s.price?.toFixed(2)}</div>
+            <div className={s.changePctDay >= 0 ? 'text-green-500 text-xs' : 'text-red-500 text-xs'}>
+              {s.changePctDay.toFixed(2)}%
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/pages/news/components/ResearchRankings.tsx
+++ b/src/pages/news/components/ResearchRankings.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react'
+import { useNews } from '@/state/newsSlice'
+
+const tabs = [
+  { key: 'momentum', label: 'Momentum (30D)' },
+  { key: 'volume', label: 'Volume Surge' },
+  { key: 'buzz', label: 'News Buzz' },
+  { key: 'composite', label: 'Composite' },
+] as const
+
+type TabKey = typeof tabs[number]['key']
+
+export default function ResearchRankings() {
+  const [active, setActive] = useState<TabKey>('momentum')
+  const { rankings, loadRankings } = useNews()
+
+  const rows = rankings
+    .slice()
+    .sort((a, b) => {
+      if (active === 'momentum') return b.momentum30d - a.momentum30d
+      if (active === 'volume') return b.volumeSurge - a.volumeSurge
+      if (active === 'buzz') return b.newsBuzz - a.newsBuzz
+      return b.composite - a.composite
+    })
+    .slice(0, 10)
+
+  return (
+    <section className="mt-6">
+      <div className="flex space-x-2 overflow-x-auto pb-2 text-xs">
+        {tabs.map((t) => (
+          <button
+            key={t.key}
+            onClick={() => {
+              setActive(t.key)
+              loadRankings()
+            }}
+            className={['px-3 py-1 rounded-full', active === t.key ? 'bg-indigo-600 text-white' : 'bg-zinc-800 text-zinc-300'].join(' ')}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <ul className="mt-2 divide-y divide-zinc-800 text-sm">
+        {rows.map((r, idx) => (
+          <li key={r.symbol} className="flex items-center py-1">
+            <span className="w-6 text-right mr-2 text-xs text-zinc-500">{idx + 1}</span>
+            <span className="w-14 font-medium">{r.symbol}</span>
+            <span className="text-zinc-400 text-xs flex-1">
+              {active === 'momentum'
+                ? r.momentum30d.toFixed(1)
+                : active === 'volume'
+                ? r.volumeSurge.toFixed(1)
+                : active === 'buzz'
+                ? r.newsBuzz.toFixed(1)
+                : r.composite.toFixed(1)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/pages/news/components/TodayBrief.tsx
+++ b/src/pages/news/components/TodayBrief.tsx
@@ -1,0 +1,31 @@
+import { useNews } from '@/state/newsSlice'
+
+export default function TodayBrief() {
+  const { brief, status } = useNews()
+
+  if (status === 'loading' && !brief) {
+    return <div className="skeleton h-20 rounded-lg my-2" />
+  }
+
+  if (!brief) return null
+
+  return (
+    <section className="mt-4">
+      <h2 className="text-sm font-medium mb-2">Today&apos;s Brief – {new Date(brief.asOf).toLocaleDateString()}</h2>
+      <ul className="list-disc pl-5 text-sm space-y-1">
+        {brief.overviewBullets.map((b) => (
+          <li key={b}>{b}</li>
+        ))}
+      </ul>
+      {brief.watchlist?.length ? (
+        <div className="mt-2 flex flex-wrap gap-1 text-xs">
+          {brief.watchlist.map((t) => (
+            <span key={t} className="rounded-full bg-zinc-800 px-2 py-0.5">
+              {t}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/src/state/newsSlice.ts
+++ b/src/state/newsSlice.ts
@@ -1,0 +1,105 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import type { DailyBrief, MarketCard, RankingRow, Headline } from '@/types/research'
+
+/**
+ * Filters used to fetch and display headlines
+ */
+export type Filters = {
+  scope: 'all' | 'holdings' | 'pinned'
+  sector?: string
+  window?: '24h' | '7d'
+}
+
+export type Status = 'idle' | 'loading' | 'ready' | 'error'
+
+interface NewsState {
+  brief?: DailyBrief
+  snapshot: MarketCard[]
+  rankings: RankingRow[]
+  headlines: Headline[]
+  filters: Filters
+  status: Status
+  setFilters: (f: Partial<Filters>) => void
+  loadBrief: () => Promise<void>
+  loadSnapshot: () => Promise<void>
+  loadRankings: (tab?: 'momentum' | 'volume' | 'buzz' | 'composite') => Promise<void>
+  loadHeadlines: () => Promise<void>
+}
+
+export const useNews = create<NewsState>()(
+  persist(
+    (set, get) => ({
+      brief: undefined,
+      snapshot: [],
+      rankings: [],
+      headlines: [],
+      filters: { scope: 'holdings', window: '24h' },
+      status: 'idle',
+
+      setFilters: (f) => set({ filters: { ...get().filters, ...f } }),
+
+      loadBrief: async () => {
+        set({ status: 'loading' })
+        try {
+          const res = await fetch('/api/research/daily-brief')
+          if (!res.ok) throw new Error('Failed to load brief')
+          const data: DailyBrief = await res.json()
+          set({ brief: data, status: 'ready' })
+        } catch (err) {
+          console.error(err)
+          set({ status: 'error' })
+        }
+      },
+
+      loadSnapshot: async () => {
+        set({ status: 'loading' })
+        try {
+          const res = await fetch('/api/market/snapshot?tickers=SPY,QQQ,DIA')
+          if (!res.ok) throw new Error('Failed to load snapshot')
+          const data: MarketCard[] = await res.json()
+          set({ snapshot: data, status: 'ready' })
+        } catch (err) {
+          console.error(err)
+          set({ status: 'error' })
+        }
+      },
+
+      loadRankings: async () => {
+        try {
+          const res = await fetch('/api/research/rankings?universe=holdings&limit=20')
+          if (!res.ok) throw new Error('Failed to load rankings')
+          const data: RankingRow[] = await res.json()
+          set({ rankings: data })
+        } catch (err) {
+          console.error(err)
+        }
+      },
+
+      loadHeadlines: async () => {
+        try {
+          const { filters } = get()
+          const params = new URLSearchParams()
+          if (filters.scope) params.set('scope', filters.scope)
+          if (filters.window) params.set('window', filters.window)
+          const res = await fetch(`/api/news/fetch?${params.toString()}`)
+          if (!res.ok) throw new Error('Failed to load headlines')
+          const data: Headline[] = await res.json()
+          set({ headlines: data })
+        } catch (err) {
+          console.error(err)
+        }
+      },
+    }),
+    {
+      name: 'newsSlice',
+      partialize: (state) => ({
+        brief: state.brief,
+        snapshot: state.snapshot,
+        rankings: state.rankings,
+        headlines: state.headlines,
+        filters: state.filters,
+      }),
+    },
+  ),
+)

--- a/src/types/research.ts
+++ b/src/types/research.ts
@@ -1,0 +1,34 @@
+export interface Headline {
+  id: string
+  title: string
+  source: string
+  url: string
+  published_at: string // ISO 8601
+  tickers: string[]
+  summary?: string
+}
+
+export interface MarketCard {
+  symbol: string
+  price: number
+  changePctDay: number
+  changePct30d: number
+  volume?: number
+  avgVolume30d?: number
+  spark?: number[] // last N closes
+}
+
+export interface RankingRow {
+  symbol: string
+  momentum30d: number // 0..100
+  volumeSurge: number // 0..100
+  newsBuzz: number // 0..100
+  composite: number // 0..100
+}
+
+export interface DailyBrief {
+  asOf: string // ISO date
+  overviewBullets: string[]
+  watchlist: string[]
+  keyStories: { title: string; takeaway: string }[]
+}


### PR DESCRIPTION
Implement the new "News & Research" page client-side to provide curated market insights and news.

This PR lays the foundation for the new `/news` route, including necessary TypeScript types, a Zustand state slice with persistence, and the initial UI components (TodayBrief, MarketSnapshot, ResearchRankings, HeadlinesForYou). It also integrates the route into the application's navigation. This is the first step in delivering the "News/Research" page as specified in the PortfolioHub 2.0 requirements, focusing on the client-side structure and data flow from the state management. Subsequent PRs will cover backend integrations (Supabase functions), offline caching (Dexie), and comprehensive testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-875d72e8-802f-414b-acaa-89323fa0461e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-875d72e8-802f-414b-acaa-89323fa0461e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

