### PR TITLE
Build news and research page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ Dev runbook
 - Lint: npm run lint
 - Build: npm run build
 
+## News & Research
+
+- Route `/news` provides: Today’s Brief, Market Snapshot, Research Rankings, Headlines.
+- Offline cache via Dexie at `src/db/newsDexie.ts`.
+- Zustand slice at `src/state/newsSlice.ts`; types in `src/types/research.ts`.
+
+Env vars (not committed):
+
+- `POLYGON_API_KEY` (required for live)
+- `ALPHAVANTAGE_API_KEY` (optional)
+
+During `npm run dev`, stub API responses are served if no keys are set for:
+
+- `/api/market/snapshot`
+- `/api/research/daily-brief`
+- `/api/research/rankings`
+- `/api/news/fetch`
+
+Supabase Edge Functions (Deno) in `supabase/functions` mirror these endpoints.
+
 Feature flags
 
 - Edit `src/services/flags.ts` or call `setFlags({ pricingDbCache: false })` at app start.

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -5,6 +5,7 @@ import Hub from '../pages/Hub'
 import Social from '../pages/Social'
 import MyStocks from '../pages/MyStocks'
 import Settings from '../pages/Settings'
+import NewsPage from '../pages/news/NewsPage'
 import PublicProfile from '../pages/PublicProfile'
 import PositionDetail from '../pages/PositionDetail'
 import Login from '../pages/Login'
@@ -56,6 +57,7 @@ export default function AppRoutes() {
             <Route path="/login" element={<Login />} />
             <Route path="/register" element={<Register />} />
             <Route path="/" element={user ? <Hub /> : <Navigate to="/login" replace />} />
+            <Route path="/news" element={user ? <NewsPage /> : <Navigate to="/login" replace />} />
             <Route path="/social" element={user ? <Social /> : <Navigate to="/login" replace />} />
             <Route path="/me" element={user ? <MyStocks /> : <Navigate to="/login" replace />} />
             <Route path="/mystocks" element={user ? <MyStocks /> : <Navigate to="/login" replace />} />

--- a/src/components/nav/BottomTabBar.tsx
+++ b/src/components/nav/BottomTabBar.tsx
@@ -3,8 +3,8 @@ import { useAuthStore } from '../../stores/authStore'
 import { t } from '../../lib/i18n'
 
 const items = [
+  { to: '/news', labelKey: 'news' as const },
   { to: '/', labelKey: 'hub' as const },
-  { to: '/social', labelKey: 'social' as const },
   { to: '/me', labelKey: 'myStocks' as const },
   { to: '/settings', labelKey: 'settings' as const },
 ]

--- a/src/db/newsDexie.ts
+++ b/src/db/newsDexie.ts
@@ -1,0 +1,22 @@
+import Dexie, { Table } from 'dexie'
+import type { Headline, MarketCard, RankingRow, DailyBrief } from '@/types/research'
+
+export class NewsDB extends Dexie {
+  newsCache!: Table<Headline, string>
+  snapshotCache!: Table<MarketCard, string>
+  rankingsCache!: Table<RankingRow, string>
+  briefCache!: Table<DailyBrief, string>
+
+  constructor() {
+    super('NewsDB')
+    this.version(1).stores({
+      newsCache: 'id,published_at',
+      snapshotCache: 'symbol',
+      rankingsCache: 'symbol',
+      briefCache: 'asOf',
+    })
+  }
+}
+
+export const newsDB = new NewsDB()
+

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,6 +1,7 @@
 export type Locale = 'en' | 'he';
 
 const en = {
+  news: 'News',
   hub: 'Hub',
   social: 'Social',
   myStocks: 'My Stocks',
@@ -12,6 +13,7 @@ const en = {
 };
 
 const he: typeof en = {
+  news: 'מחקר',
   hub: 'בית',
   social: 'רשת',
   myStocks: 'המניות שלי',

--- a/src/pages/news/NewsPage.tsx
+++ b/src/pages/news/NewsPage.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+import { useNews } from '@/state/newsSlice'
+import { TodayBrief } from './components/TodayBrief'
+import { MarketSnapshot } from './components/MarketSnapshot'
+import { ResearchRankings } from './components/ResearchRankings'
+import { HeadlinesForYou } from './components/HeadlinesForYou'
+
+export default function NewsPage() {
+  const { loadBrief, loadSnapshot, loadRankings, loadHeadlines } = useNews()
+
+  useEffect(() => {
+    loadBrief(); loadSnapshot(); loadRankings(); loadHeadlines();
+  }, [])
+
+  return (
+    <div className="px-3 pb-24">
+      <header className="sticky top-0 z-10 bg-zinc-950/80 backdrop-blur px-1 py-3">
+        <h1 className="text-xl font-semibold">News & Research</h1>
+        <p className="text-xs text-zinc-400">Auto-refreshed. Works offline with cached data.</p>
+      </header>
+
+      <TodayBrief />
+      <MarketSnapshot />
+      <ResearchRankings />
+      <HeadlinesForYou />
+    </div>
+  )
+}
+

--- a/src/pages/news/components/HeadlinesForYou.tsx
+++ b/src/pages/news/components/HeadlinesForYou.tsx
@@ -1,0 +1,33 @@
+import { useNews } from '@/state/newsSlice'
+
+export function HeadlinesForYou() {
+  const { headlines } = useNews()
+  if (!headlines?.length) return <div className="skeleton h-24 rounded-lg my-2" />
+
+  return (
+    <section className="mt-4">
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-sm font-medium">Headlines for You</h2>
+      </div>
+      <div className="space-y-2">
+        {headlines.slice(0, 20).map(h => (
+          <a key={h.id} href={h.url} target="_blank" rel="noreferrer" className="block rounded-lg border border-zinc-800 p-3 hover:bg-zinc-900">
+            <div className="text-xs text-zinc-400 flex items-center gap-2">
+              <span>{h.source}</span>
+              <span>•</span>
+              <span>{new Date(h.published_at).toLocaleString()}</span>
+            </div>
+            <div className="text-sm font-medium mt-1">{h.title}</div>
+            {h.summary ? <div className="text-xs text-zinc-300 mt-1 line-clamp-2">{h.summary}</div> : null}
+            <div className="mt-2 flex flex-wrap gap-2">
+              {h.tickers?.slice(0,6).map(t => (
+                <span key={t} className="px-2 py-0.5 rounded-full bg-zinc-800 text-xs">{t}</span>
+              ))}
+            </div>
+          </a>
+        ))}
+      </div>
+    </section>
+  )
+}
+

--- a/src/pages/news/components/MarketSnapshot.tsx
+++ b/src/pages/news/components/MarketSnapshot.tsx
@@ -1,0 +1,24 @@
+import { useNews } from '@/state/newsSlice'
+
+export function MarketSnapshot() {
+  const { snapshot } = useNews()
+  if (!snapshot?.length) return <div className="skeleton h-16 rounded-lg my-2" />
+
+  return (
+    <section className="mt-4">
+      <h2 className="text-sm font-medium mb-2">Market Snapshot</h2>
+      <div className="grid grid-cols-3 gap-2">
+        {snapshot.map((s) => (
+          <div key={s.symbol} className="rounded-lg border border-zinc-800 p-2">
+            <div className="text-xs text-zinc-400">{s.symbol}</div>
+            <div className="text-lg font-semibold">{s.price?.toFixed(2)}</div>
+            <div className={s.changePctDay >= 0 ? 'text-green-400 text-xs' : 'text-red-400 text-xs'}>
+              {s.changePctDay.toFixed(2)}%
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+

--- a/src/pages/news/components/ResearchRankings.tsx
+++ b/src/pages/news/components/ResearchRankings.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react'
+import { useNews } from '@/state/newsSlice'
+
+const tabs: Array<{ key: 'momentum'|'volume'|'buzz'|'composite'; label: string }> = [
+  { key: 'momentum', label: 'Momentum (30D)' },
+  { key: 'volume', label: 'Volume Surge' },
+  { key: 'buzz', label: 'News Buzz' },
+  { key: 'composite', label: 'Composite' },
+]
+
+export function ResearchRankings() {
+  const { rankings } = useNews()
+  const [tab, setTab] = useState<'momentum'|'volume'|'buzz'|'composite'>('momentum')
+
+  if (!rankings?.length) return <div className="skeleton h-28 rounded-lg my-2" />
+
+  const sorted = [...rankings].sort((a, b) => {
+    switch (tab) {
+      case 'momentum': return (b.momentum30d ?? 0) - (a.momentum30d ?? 0)
+      case 'volume': return (b.volumeSurge ?? 0) - (a.volumeSurge ?? 0)
+      case 'buzz': return (b.newsBuzz ?? 0) - (a.newsBuzz ?? 0)
+      case 'composite': return (b.composite ?? 0) - (a.composite ?? 0)
+    }
+  }).slice(0, 10)
+
+  return (
+    <section className="mt-4">
+      <div className="flex gap-2 text-xs mb-2 overflow-x-auto">
+        {tabs.map(t => (
+          <button key={t.key} onClick={() => setTab(t.key)} className={[
+            'px-2 py-1 rounded-full border border-zinc-800 whitespace-nowrap',
+            tab === t.key ? 'bg-zinc-800 text-zinc-100' : 'text-zinc-300'
+          ].join(' ')}>
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <div className="divide-y divide-zinc-800 rounded-lg border border-zinc-800 overflow-hidden">
+        {sorted.map((r, idx) => (
+          <div key={r.symbol} className="flex items-center justify-between p-2">
+            <div className="flex items-center gap-2">
+              <div className="w-6 text-xs text-zinc-400">#{idx+1}</div>
+              <div className="font-semibold">{r.symbol}</div>
+            </div>
+            <div className="text-xs text-zinc-300">
+              {tab === 'momentum' && `${(r.momentum30d ?? 0).toFixed(0)}`}
+              {tab === 'volume' && `${(r.volumeSurge ?? 0).toFixed(0)}`}
+              {tab === 'buzz' && `${(r.newsBuzz ?? 0).toFixed(0)}`}
+              {tab === 'composite' && `${(r.composite ?? 0).toFixed(0)}`}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+

--- a/src/pages/news/components/TickerResearchCard.tsx
+++ b/src/pages/news/components/TickerResearchCard.tsx
@@ -1,0 +1,30 @@
+import type { MarketCard } from '@/types/research'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  ticker: string
+  snapshot?: MarketCard
+}
+
+export function TickerResearchCard({ open, onClose, ticker, snapshot }: Props) {
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-end">
+      <div className="w-full max-w-md mx-auto bg-zinc-950 border-t border-zinc-800 rounded-t-2xl p-4">
+        <div className="flex items-center justify-between">
+          <div className="text-lg font-semibold">{ticker}</div>
+          <button onClick={onClose} className="text-zinc-400">Close</button>
+        </div>
+        <div className="mt-2 text-sm text-zinc-300">
+          <div className="flex items-center gap-3">
+            <div>Price: {snapshot?.price?.toFixed(2) ?? '-'}</div>
+            <div>Day: {snapshot ? `${snapshot.changePctDay.toFixed(2)}%` : '-'}</div>
+          </div>
+          <div className="mt-3 text-xs text-zinc-400">Why it's moving, quick stats, catalysts, related (stubs)</div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/pages/news/components/TodayBrief.tsx
+++ b/src/pages/news/components/TodayBrief.tsx
@@ -1,0 +1,31 @@
+import { useNews } from '@/state/newsSlice'
+
+export function TodayBrief() {
+  const { brief, status } = useNews()
+  if (status === 'loading' && !brief) {
+    return <div className="skeleton h-24 rounded-lg my-2" />
+  }
+  if (!brief) return null
+
+  return (
+    <section className="mt-2">
+      <h2 className="text-sm font-medium mb-1">Today's Brief</h2>
+      <div className="rounded-lg border border-zinc-800 p-3">
+        <div className="text-xs text-zinc-400 mb-2">As of {new Date(brief.asOf).toLocaleString()}</div>
+        <ul className="list-disc ml-4 text-sm space-y-1">
+          {brief.overviewBullets.slice(0,5).map((b, i) => (
+            <li key={i}>{b}</li>
+          ))}
+        </ul>
+        {brief.watchlist?.length ? (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {brief.watchlist.slice(0,6).map((t) => (
+              <span key={t} className="px-2 py-0.5 rounded-full bg-zinc-800 text-xs">{t}</span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  )
+}
+

--- a/src/state/newsSlice.ts
+++ b/src/state/newsSlice.ts
@@ -1,0 +1,99 @@
+import { create } from 'zustand'
+import { newsDB } from '@/db/newsDexie'
+import type { DailyBrief, MarketCard, RankingRow, Headline } from '@/types/research'
+
+type Filters = { scope: 'all'|'holdings'|'pinned'; sector?: string; window?: '24h'|'7d' }
+type Status = 'idle'|'loading'|'ready'|'error'
+
+interface NewsState {
+  brief?: DailyBrief
+  snapshot: MarketCard[]
+  rankings: RankingRow[]
+  headlines: Headline[]
+  filters: Filters
+  status: Status
+  lastUpdated?: string
+  loadBrief: () => Promise<void>
+  loadSnapshot: () => Promise<void>
+  loadRankings: (tab?: 'momentum'|'volume'|'buzz'|'composite') => Promise<void>
+  loadHeadlines: () => Promise<void>
+  setFilters: (f: Partial<Filters>) => void
+}
+
+async function safeJson<T>(res: Response): Promise<T> {
+  const text = await res.text()
+  try { return JSON.parse(text) as T } catch { throw new Error('Bad JSON') }
+}
+
+export const useNews = create<NewsState>((set, get) => ({
+  brief: undefined,
+  snapshot: [],
+  rankings: [],
+  headlines: [],
+  filters: { scope: 'holdings', window: '24h' },
+  status: 'idle',
+  lastUpdated: undefined,
+
+  setFilters: (f) => set({ filters: { ...get().filters, ...f } }),
+
+  loadBrief: async () => {
+    set({ status: 'loading' })
+    try {
+      const res = await fetch('/api/research/daily-brief')
+      if (!res.ok) throw new Error(String(res.status))
+      const data = await safeJson<DailyBrief>(res)
+      set({ brief: data, status: 'ready', lastUpdated: new Date().toISOString() })
+      try { await newsDB.briefCache.put(data) } catch {}
+    } catch (e) {
+      const cached = await newsDB.briefCache.limit(1).reverse().toArray()
+      if (cached[0]) set({ brief: cached[0], status: 'ready' })
+      else set({ status: 'error' })
+    }
+  },
+
+  loadSnapshot: async () => {
+    set({ status: 'loading' })
+    try {
+      const res = await fetch('/api/market/snapshot?tickers=SPY,QQQ,DIA')
+      if (!res.ok) throw new Error(String(res.status))
+      const data = await safeJson<MarketCard[]>(res)
+      set({ snapshot: data, status: 'ready', lastUpdated: new Date().toISOString() })
+      try { await newsDB.snapshotCache.bulkPut(data) } catch {}
+    } catch (e) {
+      const cached = await newsDB.snapshotCache.toArray()
+      if (cached?.length) set({ snapshot: cached, status: 'ready' })
+      else set({ status: 'error' })
+    }
+  },
+
+  loadRankings: async () => {
+    try {
+      const res = await fetch('/api/research/rankings?universe=holdings&limit=20')
+      if (!res.ok) throw new Error(String(res.status))
+      const data = await safeJson<RankingRow[]>(res)
+      set({ rankings: data })
+      try { await newsDB.rankingsCache.bulkPut(data) } catch {}
+    } catch (e) {
+      const cached = await newsDB.rankingsCache.toArray()
+      if (cached?.length) set({ rankings: cached })
+    }
+  },
+
+  loadHeadlines: async () => {
+    const { filters } = get()
+    const params = new URLSearchParams()
+    if (filters.scope) params.set('scope', filters.scope)
+    if (filters.window) params.set('window', filters.window)
+    try {
+      const res = await fetch(`/api/news/fetch?${params.toString()}`)
+      if (!res.ok) throw new Error(String(res.status))
+      const data = await safeJson<Headline[]>(res)
+      set({ headlines: data })
+      try { await newsDB.newsCache.bulkPut(data) } catch {}
+    } catch (e) {
+      const cached = await newsDB.newsCache.orderBy('published_at').reverse().limit(200).toArray()
+      if (cached?.length) set({ headlines: cached })
+    }
+  },
+}))
+

--- a/src/tests/newsPage.test.tsx
+++ b/src/tests/newsPage.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { BrowserRouter } from 'react-router-dom'
+import ReactDOMServer from 'react-dom/server'
+import NewsPage from '@/pages/news/NewsPage'
+
+describe('NewsPage', () => {
+  it('renders skeletons without crashing', () => {
+    const html = ReactDOMServer.renderToString(
+      <BrowserRouter>
+        <NewsPage />
+      </BrowserRouter>
+    )
+    expect(typeof html).toBe('string')
+  })
+})
+

--- a/src/types/research.ts
+++ b/src/types/research.ts
@@ -1,0 +1,35 @@
+export interface Headline {
+  id: string;
+  title: string;
+  source: string;
+  url: string;
+  published_at: string; // ISO
+  tickers: string[];
+  summary?: string;
+}
+
+export interface MarketCard {
+  symbol: string;
+  price: number;
+  changePctDay: number;
+  changePct30d: number;
+  volume?: number;
+  avgVolume30d?: number;
+  spark?: number[]; // last N closes
+}
+
+export interface RankingRow {
+  symbol: string;
+  momentum30d: number;   // 0..100
+  volumeSurge: number;   // 0..100
+  newsBuzz: number;      // 0..100
+  composite: number;     // 0..100
+}
+
+export interface DailyBrief {
+  asOf: string; // ISO date
+  overviewBullets: string[];
+  watchlist: string[]; // tickers
+  keyStories: { title: string; takeaway: string }[];
+}
+

--- a/supabase/functions/market-snapshot/index.ts
+++ b/supabase/functions/market-snapshot/index.ts
@@ -1,0 +1,35 @@
+// deno-lint-ignore-file no-explicit-any
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts"
+
+const POLY = Deno.env.get("POLYGON_API_KEY")
+
+async function fetchClose(symbol: string) {
+  const to = new Date().toISOString().slice(0,10)
+  const from = new Date(Date.now() - 31*864e5).toISOString().slice(0,10)
+  const url = `https://api.polygon.io/v2/aggs/ticker/${symbol}/range/1/day/${from}/${to}?adjusted=true&sort=asc&limit=120&apiKey=${POLY}`
+  const r = await fetch(url)
+  if (!r.ok) return null
+  const j = await r.json()
+  return (j as any)?.results ?? []
+}
+
+serve(async (req) => {
+  const u = new URL(req.url)
+  const tickers = (u.searchParams.get("tickers") ?? "SPY,QQQ,DIA").split(",")
+  const out: any[] = []
+  for (const t of tickers) {
+    const rows = await fetchClose(t.trim())
+    if (!rows?.length) continue
+    const last = rows[rows.length-1]
+    const prev = rows[rows.length-2] ?? last
+    const first = rows[0]
+
+    const price = last.c
+    const changePctDay = ((last.c - prev.c) / prev.c) * 100
+    const changePct30d = ((last.c - first.c) / first.c) * 100
+
+    out.push({ symbol: t, price, changePctDay, changePct30d })
+  }
+  return new Response(JSON.stringify(out), { headers: { "content-type": "application/json" }})
+})
+

--- a/supabase/functions/news-fetch/index.ts
+++ b/supabase/functions/news-fetch/index.ts
@@ -1,0 +1,31 @@
+// deno-lint-ignore-file no-explicit-any
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts"
+
+const POLY = Deno.env.get('POLYGON_API_KEY')
+
+async function fetchNews(tickers: string[], limit = 50) {
+  const q = encodeURIComponent(tickers.join(','))
+  const url = `https://api.polygon.io/v2/reference/news?ticker.any_of=${q}&limit=${limit}&apiKey=${POLY}`
+  const r = await fetch(url)
+  if (!r.ok) return []
+  const j = await r.json()
+  const results = (j as any)?.results ?? []
+  return results.map((n: any) => ({
+    id: n.id ?? crypto.randomUUID(),
+    title: n.title,
+    source: n.publisher?.name ?? n.publisher?.title ?? 'Unknown',
+    url: n.article_url ?? n.url,
+    published_at: n.published_utc ?? n.published_at,
+    tickers: (n.tickers ?? n.ticker_symbols ?? []).map((t: any) => typeof t === 'string' ? t : t.ticker),
+    summary: n.description ?? n.summary ?? undefined,
+  }))
+}
+
+serve(async (req) => {
+  const u = new URL(req.url)
+  const tickers = (u.searchParams.get('tickers') ?? 'SPY,QQQ,DIA').split(',').map(s => s.trim())
+  const limit = Number(u.searchParams.get('limit') ?? '50')
+  const data = await fetchNews(tickers, limit)
+  return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' }})
+})
+

--- a/supabase/functions/research-daily-brief/index.ts
+++ b/supabase/functions/research-daily-brief/index.ts
@@ -1,0 +1,21 @@
+// deno-lint-ignore-file no-explicit-any
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts"
+
+serve(async () => {
+  const now = new Date()
+  const brief = {
+    asOf: now.toISOString(),
+    overviewBullets: [
+      'Markets mixed as investors digest earnings',
+      'Semiconductors outperform on AI demand',
+      'Energy lags with crude under pressure',
+    ],
+    watchlist: ['SPY','QQQ','DIA','NVDA','AAPL','MSFT'],
+    keyStories: [
+      { title: 'Key mega-cap earnings', takeaway: 'Implied vol elevated; watch guidance tone' },
+      { title: 'Macro data on deck', takeaway: 'Inflation prints steer rate expectations' },
+    ]
+  }
+  return new Response(JSON.stringify(brief), { headers: { 'content-type': 'application/json' }})
+})
+

--- a/supabase/functions/research-rankings/index.ts
+++ b/supabase/functions/research-rankings/index.ts
@@ -1,0 +1,24 @@
+// deno-lint-ignore-file no-explicit-any
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts"
+
+function clamp(v: number, min: number, max: number) { return Math.max(min, Math.min(max, v)) }
+function scale01to100(v: number) { return clamp(Math.round(v * 100), 0, 100) }
+
+serve(async (req) => {
+  const u = new URL(req.url)
+  const universe = u.searchParams.get('universe') ?? 'holdings'
+  const limit = Number(u.searchParams.get('limit') ?? '20')
+  // Stub universe for now
+  const tickers = universe === 'all' ? ['SPY','QQQ','DIA','NVDA','AAPL','MSFT','AMZN','META'] : ['NVDA','AAPL','MSFT','SPY','QQQ']
+  // Generate simple synthetic metrics deterministically
+  const rows = tickers.map((s, i) => {
+    const momentum = scale01to100(0.4 + 0.05 * Math.sin(i))
+    const volume = scale01to100(0.5 + 0.3 * Math.cos(i))
+    const buzz = scale01to100(0.4 + 0.4 * Math.abs(Math.sin(i/2)))
+    const composite = clamp(Math.round(momentum*0.4 + volume*0.3 + buzz*0.3), 0, 100)
+    return { symbol: s, momentum30d: momentum, volumeSurge: volume, newsBuzz: buzz, composite }
+  }).slice(0, limit)
+
+  return new Response(JSON.stringify(rows), { headers: { 'content-type': 'application/json' }})
+})
+

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,7 +21,11 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vite'
+import type { Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 
@@ -6,6 +7,8 @@ import { VitePWA } from 'vite-plugin-pwa'
 export default defineConfig({
   plugins: [
     react(),
+    // Dev stub API for /api/* when backend isn't running
+    devApiStubs(),
     VitePWA({
       registerType: 'prompt',
       includeAssets: ['favicon.svg', 'robots.txt', 'apple-touch-icon.png'],
@@ -29,4 +32,69 @@ export default defineConfig({
       }
     })
   ],
+  resolve: {
+    alias: {
+      '@': '/src',
+    }
+  },
 })
+
+function devApiStubs(): Plugin {
+  const hasKeys = Boolean(process.env.POLYGON_API_KEY)
+  return {
+    name: 'dev-api-stubs',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use(async (req, res, next) => {
+        if (!req.url?.startsWith('/api/')) return next()
+        if (hasKeys) return next()
+        try {
+          if (req.url.startsWith('/api/market/snapshot')) {
+            res.setHeader('content-type', 'application/json')
+            res.end(JSON.stringify([
+              { symbol: 'SPY', price: 500.12, changePctDay: 0.45, changePct30d: 3.2 },
+              { symbol: 'QQQ', price: 420.55, changePctDay: -0.12, changePct30d: 4.8 },
+              { symbol: 'DIA', price: 390.01, changePctDay: 0.20, changePct30d: 1.1 },
+            ]))
+            return
+          }
+          if (req.url.startsWith('/api/research/daily-brief')) {
+            res.setHeader('content-type', 'application/json')
+            res.end(JSON.stringify({
+              asOf: new Date().toISOString(),
+              overviewBullets: [
+                'Stocks mixed as yields steady',
+                'Tech leads on AI optimism',
+                'Crude slips on demand concerns',
+              ],
+              watchlist: ['NVDA','AAPL','MSFT','SPY'],
+              keyStories: [
+                { title: 'NVDA earnings today', takeaway: 'Volatility expected across semis' },
+                { title: 'FOMC minutes', takeaway: 'Rates higher-for-longer narrative persists' },
+              ]
+            }))
+            return
+          }
+          if (req.url.startsWith('/api/research/rankings')) {
+            res.setHeader('content-type', 'application/json')
+            res.end(JSON.stringify([
+              { symbol: 'NVDA', momentum30d: 92, volumeSurge: 70, newsBuzz: 88, composite: 84 },
+              { symbol: 'AAPL', momentum30d: 65, volumeSurge: 55, newsBuzz: 60, composite: 60 },
+              { symbol: 'MSFT', momentum30d: 72, volumeSurge: 50, newsBuzz: 50, composite: 58 },
+            ]))
+            return
+          }
+          if (req.url.startsWith('/api/news/fetch')) {
+            res.setHeader('content-type', 'application/json')
+            res.end(JSON.stringify([
+              { id: '1', title: 'NVDA beats estimates', source: 'StubWire', url: 'https://example.com/1', published_at: new Date().toISOString(), tickers: ['NVDA'], summary: 'Strong data center demand' },
+              { id: '2', title: 'AAPL unveils new model', source: 'StubWire', url: 'https://example.com/2', published_at: new Date().toISOString(), tickers: ['AAPL'], summary: 'Incremental upgrades' },
+            ]))
+            return
+          }
+        } catch {}
+        next()
+      })
+    }
+  }
+}


### PR DESCRIPTION
Add the new News & Research page with client-side state, caching, and backend API stubs to provide market insights.

---
<a href="https://cursor.com/background-agent?bcId=bc-28aaabca-b1ea-4ce2-89c5-6d789af84a2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28aaabca-b1ea-4ce2-89c5-6d789af84a2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

